### PR TITLE
feat: add delete comment at cursor functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Delete comment at cursor position with `<leader>rd` keymap and `:CodeReviewDeleteComment` command
+
 ## [0.2.0] - 2025-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ require('code-review').setup({
     save = '<leader>rw',
 copy = '<leader>ry',
     show_comment = '<leader>rs',
+    list_comments = '<leader>rl',
+    delete_comment = '<leader>rd',
   },
 })
 ```
@@ -251,6 +253,7 @@ end
 | `:CodeReviewSave [path]` | `<leader>rw` | Save review to file |
 | `:CodeReviewCopy` | `<leader>ry` | Copy review to clipboard |
 | `:CodeReviewClear` | `<leader>rx` | Clear all review comments |
+| `:CodeReviewDeleteComment` | `<leader>rd` | Delete comment at cursor position |
 
 ### Visual Indicators
 
@@ -270,6 +273,7 @@ end
 | `require('code-review').save(path)` | Save to file |
 | `require('code-review').copy()` | Copy to clipboard |
 | `require('code-review').clear()` | Clear all comments |
+| `require('code-review').delete_comment_at_cursor()` | Delete comment at cursor |
 
 ### Visual Mode Selection
 

--- a/lua/code-review/config.lua
+++ b/lua/code-review/config.lua
@@ -86,6 +86,11 @@ local defaults = {
       mode = "n",
       key = "<leader>rl",
     },
+    -- Delete comment at cursor
+    delete_comment = {
+      mode = "n",
+      key = "<leader>rd",
+    },
   },
   -- Integration settings
   integrations = {

--- a/lua/code-review/init.lua
+++ b/lua/code-review/init.lua
@@ -276,8 +276,8 @@ function M.delete_comment_at_cursor()
     end)
   else
     -- Single comment, confirm deletion
-    local comment = line_comments[1]
-    local first_line = comment.comment:match("^[^\n]*") or comment.comment
+    local comment_data = line_comments[1]
+    local first_line = comment_data.comment:match("^[^\n]*") or comment_data.comment
     if #first_line > 50 then
       first_line = first_line:sub(1, 47) .. "..."
     end
@@ -286,7 +286,7 @@ function M.delete_comment_at_cursor()
       prompt = string.format("Delete comment: %s?", first_line),
     }, function(choice)
       if choice == "Yes" then
-        state.delete_comment(comment.id)
+        state.delete_comment(comment_data.id)
         require("code-review.comment").update_indicators()
         vim.notify("Comment deleted")
       end


### PR DESCRIPTION
## Summary

Adds the ability to delete comments at cursor position with `<leader>rd` or `:CodeReviewDeleteComment`.

## Features

- New command `:CodeReviewDeleteComment` to delete comment at cursor
- Default keymap `<leader>rd` for quick deletion
- Confirmation prompt before deletion to prevent accidents
- Multi-comment selection when multiple comments exist at the same line
- Automatic update of visual indicators (signs and virtual text) after deletion

## Testing

1. Add some comments to a file
2. Move cursor to a commented line
3. Press `<leader>rd` or run `:CodeReviewDeleteComment`
4. Confirm deletion in the prompt
5. Verify that the comment is removed and indicators are updated

## Related

Addresses the need to remove individual comments without clearing all comments.