### PR TITLE
Fix virtual text not clearing when deleting comments

### DIFF
--- a/lua/code-review/init.lua
+++ b/lua/code-review/init.lua
@@ -115,6 +115,7 @@ end
 --- Clear all comments
 function M.clear()
   state.clear()
+  comment.update_indicators()
 end
 
 --- Add a comment at the current location


### PR DESCRIPTION
## Summary
- Fixed an issue where virtual text indicators remained visible after deleting comments
- The root cause was that namespace IDs were being recreated on each function call, causing mismatches between creation and deletion

## Changes
- Created namespace IDs once at module load time instead of recreating them on each call
- Updated all functions to use the consistent namespace IDs
- This ensures that `clear_indicators()` properly clears the virtual text created by `add_virtual_text()`

## Test plan
- [ ] Add a comment to a line
- [ ] Verify virtual text appears at the end of the line
- [ ] Delete the comment using `:CodeReviewDeleteComment`
- [ ] Verify virtual text is properly removed
- [ ] Add multiple comments and verify clearing works correctly