### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Stylua
         uses: JohnnyMorganz/stylua-action@v4
         with:
@@ -23,12 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install luacheck
         run: |
           sudo apt-get update
           sudo apt-get install -y luarocks
           sudo luarocks install luacheck
-      
+
       - name: Run luacheck
         run: luacheck .
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract release notes
+        id: extract_notes
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+          # Extract release notes from CHANGELOG.md
+          awk -v version="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if ($2 == "[" version "]") {
+                found = 1
+                next
+              }
+            }
+            found && /^## \[/ {
+              exit
+            }
+            found {
+              print
+            }
+          ' CHANGELOG.md > release_notes.md
+
+          # Remove empty lines at the beginning
+          sed -i '/./,$!d' release_notes.md
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.extract_notes.outputs.VERSION }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to automatically create releases when version tags are pushed.

## Details
- Triggers on version tags (v*)
- Extracts release notes from CHANGELOG.md
- Creates GitHub release with proper release notes
- Non-draft, non-prerelease by default

## Test plan
The workflow will be tested when we create the next release tag.