### PR TITLE
fix: release workflow to handle version tags correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,12 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          
+          # Remove 'v' prefix for CHANGELOG lookup
+          CHANGELOG_VERSION=${VERSION#v}
 
           # Extract release notes from CHANGELOG.md
-          awk -v version="$VERSION" '
+          awk -v version="$CHANGELOG_VERSION" '
             /^## \[/ {
               if (found) exit
               if ($2 == "[" version "]") {


### PR DESCRIPTION
## Summary
Fix the release workflow to correctly extract release notes from CHANGELOG.md

## Problem
The current workflow fails to extract release notes because:
- Git tags have 'v' prefix (e.g., v0.3.0)
- CHANGELOG.md versions don't have 'v' prefix (e.g., [0.3.0])

## Solution
Remove the 'v' prefix when looking up versions in CHANGELOG.md

## Test plan
After merging, we can update the existing v0.3.0 release or create a new tag to test.