### PR TITLE
refactor!: remove JSON format support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - File-based storage backend option for persistent comment storage
 
+### Removed
+- JSON output format support - all outputs are now in Markdown format only
+- `output.format` configuration option
+- `ui.preview.format` configuration option
+
 ## [0.3.0] - 2025-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ require('code-review').setup({
     },
     -- Preview window
     preview = {
-      format = 'markdown', -- 'markdown', 'json', or 'auto' (same as output.format)
       split = 'vertical', -- 'vertical', 'horizontal', or 'float'
       vertical_width = 80,
       horizontal_height = 20,
@@ -128,7 +127,6 @@ require('code-review').setup({
   },
   -- Output settings
   output = {
-    format = 'markdown', -- 'markdown' or 'json'
     date_format = '%Y-%m-%d %H:%M:%S',
     save_dir = nil, -- nil = current directory
   },
@@ -340,9 +338,9 @@ Perfect for PR reviews! Use code-review.nvim alongside [diffview.nvim](https://g
 - Add comments while comparing changes
 - See context from both old and new versions
 
-## 📄 Output Formats
+## 📄 Output Format
 
-### Markdown Format
+Reviews are saved in a clean, readable Markdown format:
 
 ````markdown
 # Code Review
@@ -377,25 +375,6 @@ This function needs error handling for nil input.
 Consider using table.filter for better readability.
 ````
 
-### JSON Format
-
-```json
-{
-  "date": "2024-01-30 14:30:00",
-  "comment_count": 2,
-  "comments": [
-    {
-      "id": "1706621400_1234",
-      "file": "src/main.lua",
-      "line_start": 42,
-      "line_end": 42,
-      "comment": "This function needs error handling for nil input.",
-      "timestamp": 1706621400,
-      "context_lines": ["local function process_data(input)"]
-    }
-  ]
-}
-```
 
 ## 💾 Storage Backends
 

--- a/lua/code-review/config.lua
+++ b/lua/code-review/config.lua
@@ -15,7 +15,6 @@ local defaults = {
     },
     -- Preview window settings
     preview = {
-      format = "markdown", -- 'markdown' or 'json' or 'auto' (auto = same as output.format)
       split = "vertical", -- 'vertical' or 'horizontal' or 'float'
       vertical_width = 80,
       horizontal_height = 20,
@@ -44,7 +43,6 @@ local defaults = {
   },
   -- Output settings
   output = {
-    format = "markdown", -- 'markdown' or 'json'
     date_format = "%Y-%m-%d %H:%M:%S",
     -- Default save directory (nil means current directory)
     save_dir = nil,

--- a/lua/code-review/init.lua
+++ b/lua/code-review/init.lua
@@ -134,17 +134,8 @@ function M.preview()
     return
   end
 
-  -- Determine preview format
-  local preview_format = config.get("ui.preview.format")
-  local format
-  if preview_format == "auto" then
-    format = config.get("output.format")
-  else
-    format = preview_format
-  end
-
-  local content = formatter.format(comments, format)
-  ui.show_preview(content, format)
+  local content = formatter.format(comments)
+  ui.show_preview(content, "markdown")
 end
 
 --- Save review to file
@@ -156,13 +147,12 @@ function M.save(path)
     return
   end
 
-  local format = config.get("output.format")
   local review_utils = require("code-review.utils")
 
   -- Generate default path if not provided
   if not path then
     local save_dir = config.get("output.save_dir") or vim.fn.getcwd()
-    local filename = review_utils.generate_filename(format)
+    local filename = review_utils.generate_filename("markdown")
     local default_path = vim.fn.fnamemodify(save_dir .. "/" .. filename, ":p")
 
     -- Use vim.ui.input to get the save path
@@ -172,14 +162,14 @@ function M.save(path)
       completion = "file",
     }, function(input)
       if input and input ~= "" then
-        local content = formatter.format(comments, format)
-        formatter.save_to_file(content, input, format)
+        local content = formatter.format(comments)
+        formatter.save_to_file(content, input)
       end
     end)
   else
     -- If path is provided, save directly
-    local content = formatter.format(comments, format)
-    formatter.save_to_file(content, path, format)
+    local content = formatter.format(comments)
+    formatter.save_to_file(content, path)
   end
 end
 
@@ -191,8 +181,7 @@ function M.copy()
     return
   end
 
-  local format = config.get("output.format")
-  local content = formatter.format(comments, format)
+  local content = formatter.format(comments)
   vim.fn.setreg("+", content)
   vim.notify("Code reviews copied to clipboard")
 end

--- a/lua/code-review/ui.lua
+++ b/lua/code-review/ui.lua
@@ -188,7 +188,7 @@ end
 
 --- Show preview window
 ---@param content string The formatted content
----@param format string 'markdown' or 'json'
+---@param format string Deprecated, always uses markdown
 function M.show_preview(content, format)
   local conf = config.get("ui.preview")
   local buf
@@ -228,7 +228,7 @@ function M.show_preview(content, format)
 
   -- Set buffer content and options
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(content, "\n"))
-  vim.api.nvim_buf_set_option(buf, "filetype", format == "json" and "json" or "markdown")
+  vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
   vim.api.nvim_buf_set_option(buf, "buftype", "acwrite")
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
   -- Set unique buffer name for identification
@@ -252,7 +252,7 @@ function M.show_preview(content, format)
   vim.api.nvim_create_autocmd("BufWriteCmd", {
     buffer = buf,
     callback = function()
-      M.handle_preview_save(buf, format)
+      M.handle_preview_save(buf)
       vim.api.nvim_buf_set_option(buf, "modified", false)
     end,
   })
@@ -260,14 +260,13 @@ end
 
 --- Handle saving preview buffer
 ---@param bufnr number
----@param format string
-function M.handle_preview_save(bufnr, format)
+function M.handle_preview_save(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local content = table.concat(lines, "\n")
 
   -- Parse content back to comments
   local formatter = require("code-review.formatter")
-  local success, comments = pcall(formatter.parse, content, format)
+  local success, comments = pcall(formatter.parse, content)
 
   if not success then
     vim.notify("Failed to parse preview content: " .. tostring(comments), vim.log.levels.ERROR)

--- a/lua/code-review/utils.lua
+++ b/lua/code-review/utils.lua
@@ -107,12 +107,11 @@ function M.escape_pattern(str)
 end
 
 --- Create a unique file name for saving
----@param format string 'markdown' or 'json'
+---@param format string Deprecated, always uses markdown
 ---@return string
 function M.generate_filename(format)
-  local ext = format == "json" and "json" or "md"
   local timestamp = os.date("%Y-%m-%d-%H%M%S")
-  return string.format("code-review-%s.%s", timestamp, ext)
+  return string.format("code-review-%s.md", timestamp)
 end
 
 --- Copy text to clipboard


### PR DESCRIPTION
## Breaking Change

This PR removes JSON format support from the plugin. All outputs are now in Markdown format only.

## Rationale

With the introduction of file-based storage that saves comments as `.md` files, having JSON as an output format creates inconsistency. Markdown is more readable for code reviews and the JSON format added unnecessary complexity without clear benefits.

## Changes

- Removed all JSON-related code from `formatter.lua`
- Removed `output.format` configuration option
- Removed `ui.preview.format` configuration option  
- Simplified function signatures by removing format parameters
- Updated documentation

## Migration Guide

If you have these in your config:
```lua
output = {
  format = 'json',  -- or 'markdown'
}
```

Simply remove the `format` line. The plugin now always uses Markdown.