### PR TITLE
fix(formatter): resolve comment loss during markdown parsing

### DIFF
--- a/lua/code-review/formatter.lua
+++ b/lua/code-review/formatter.lua
@@ -105,6 +105,11 @@ function M.parse_markdown(content)
 
     -- File header
     if line:match("^##%s+(.+)") then
+      -- Save any pending comment before starting new file
+      if current_comment and current_comment.comment and current_comment.comment ~= "" then
+        table.insert(comments, current_comment)
+      end
+
       local file = line:match("^##%s+(.+)")
       current_comment = { file = file }
       i = i + 1
@@ -157,6 +162,12 @@ function M.parse_markdown(content)
       if num and code then
         table.insert(current_comment.context_lines, code)
       end
+      i = i + 1
+      goto continue
+    end
+
+    -- Skip Time line
+    if line:match("^%*%*Time%*%*:") then
       i = i + 1
       goto continue
     end

--- a/lua/code-review/state.lua
+++ b/lua/code-review/state.lua
@@ -156,4 +156,11 @@ function M.get_comments_at_location(file, line)
   return get_storage().get_at_location(file, line)
 end
 
+--- Reset internal state (for testing purposes)
+---@private
+function M._reset()
+  initialized = false
+  storage = nil
+end
+
 return M

--- a/lua/code-review/storage/memory.lua
+++ b/lua/code-review/storage/memory.lua
@@ -86,4 +86,12 @@ function M.get_at_location(file, line)
   return results
 end
 
+--- Reset internal state (for testing purposes)
+---@private
+function M._reset()
+  session.active = false
+  session.comments = {}
+  session.start_time = nil
+end
+
 return M


### PR DESCRIPTION
## Summary
- Fix critical bug where comments were lost when parsing multiple files in markdown format
- Add `_reset()` methods to state and memory modules for better test support
- Skip `**Time**:` lines to prevent incorrect parsing as comment content

## Problem
The formatter would lose pending comments when encountering a new file header during markdown parsing. This happened because the parser didn't save the current comment before processing a new file section.

## Solution
Added logic to save any pending comment before processing new file headers, ensuring no comments are lost during the parsing process.

## Test plan
- [x] All existing tests pass
- [ ] Manual testing with multiple files containing comments
- [ ] Verify markdown round-trip (format → parse) preserves all comments

## Additional changes
Added `_reset()` methods to support proper test isolation:
- `state._reset()`: Resets internal initialization state
- `memory._reset()`: Clears session data

These methods are marked as `@private` and intended for testing purposes only.