### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-07-12
+
 ### Added
 - Filename-based thread status management system (#14)
   - Comment files now use status prefixes: `action-required_*.md`, `waiting-review_*.md`, `resolved_*.md`
   - Status automatically updates when replying to threads
   - Status-specific colors and icons in UI
-- Optional status management configuration
+- Optional status management configuration (#16)
   - New `comment.status_management` configuration option (default: false)
   - Status management only works when both `storage.backend = "file"` and `status_management = true`
   - Warning messages when trying to resolve/reopen threads with status management disabled


### PR DESCRIPTION
## Release v0.5.0

### Changelog

#### Added
- Filename-based thread status management system (#14)
  - Comment files now use status prefixes: `action-required_*.md`, `waiting-review_*.md`, `resolved_*.md`
  - Status automatically updates when replying to threads
  - Status-specific colors and icons in UI
- Optional status management configuration (#16)
  - New `comment.status_management` configuration option (default: false)
  - Status management only works when both `storage.backend = "file"` and `status_management = true`
  - Warning messages when trying to resolve/reopen threads with status management disabled

### Release checklist
- [x] Update CHANGELOG.md with release date
- [x] Create and push tag v0.5.0
- [ ] Merge this PR
- [ ] GitHub Actions will automatically create the release